### PR TITLE
Command execution reliability

### DIFF
--- a/cgit/Dockerfile
+++ b/cgit/Dockerfile
@@ -1,8 +1,12 @@
 FROM fedora:28
 MAINTAINER Stuart Auchterlonie <stuarta@mythtv.org>
-RUN dnf -y update; dnf -y install httpd cgit; dnf clean all
-RUN groupadd -g 493 git; useradd -u 511 -g 493 -s /bin/bash git; usermod -aG git apache
-RUN sed -i 's/%h/%a/g' /etc/httpd/conf/httpd.conf
+RUN dnf -y update && \
+    dnf -y install httpd cgit && \
+    dnf clean all && \
+    groupadd -g 493 git && \
+    useradd -u 511 -g 493 -s /bin/bash git && \
+    usermod -aG git apache && \
+    sed -i 's/%h/%a/g' /etc/httpd/conf/httpd.conf
 
 ADD 00-mod_remoteip.conf /etc/httpd/conf.d/
 ADD 00-server-limits.conf /etc/httpd/conf.d/


### PR DESCRIPTION
Enhance then command execution in the Dockerfile. For eg, in the layer `RUN dnf -y update; dnf -y install httpd cgit` : if `dnf -y update` fails for any reason, `dnf -y install httpd cgit` will be run : this is not reliable.
This patch merge the three layer with a `RUN` command and make sure that if a command fails, the subsequent are not run.

References : [docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)