### PR TITLE
Command execution reliability for smolt

### DIFF
--- a/smolt/Dockerfile
+++ b/smolt/Dockerfile
@@ -2,7 +2,12 @@ FROM centos:6
 MAINTAINER Stuart Auchterlonie <stuarta@mythtv.org>
 # Setup EPEL
 #RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-RUN groupadd -r smoon -g 5000 && useradd -u 5000 -g smoon -m -d /home/smoon -s /sbin/nologin -c "Smoon User" smoon; yum -y update; yum -y install python-setuptools mysql-libs cronie 
+RUN groupadd -r smoon -g 5000 && \
+    useradd -u 5000 -g smoon -m -d /home/smoon -s /sbin/nologin -c "Smoon User" smoon && \
+    yum -y update && \
+    yum -y install python-setuptools mysql-libs cronie && \
+    yum clean all
+
 COPY smolt-cron /etc/cron.d/smolt
 # These are only needed to rebuild the python venv
 #RUN yum -y install mysql-devel gcc python-devel


### PR DESCRIPTION
Enhance then command execution in the Dockerfile. For eg, in the layer `RUN yum -y update; yum -y install python-setuptools` : if `yum -y update` fails for any reason, `yum -y install ..` will be run : this is not reliable.
This patch make sure that if a command fails, the subsequent are not run. Moreover, it adds a cleaning of the yum local repository in order to have a smaller image : new size is 286 MB compared to 322 MB initially.

References : [docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)